### PR TITLE
Use k8s_version as kube_version kubespray_k8s_cluster.tpl

### DIFF
--- a/templates/kubespray_k8s_cluster.tpl
+++ b/templates/kubespray_k8s_cluster.tpl
@@ -19,7 +19,7 @@ kube_users_dir: "{{ kube_config_dir }}/users"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.10.2
+kube_version: ${kube_version}
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
I believe the kube_version variable should match the version from k8s_version terraform.tfvars.