### PR TITLE
added variable to specify interface name for HAProxy builds

### DIFF
--- a/templates/keepalived_master.tpl
+++ b/templates/keepalived_master.tpl
@@ -10,7 +10,7 @@ vrrp_script check_haproxy {
 
 vrrp_instance VI_01 {
     state MASTER
-    interface ens160
+    interface ${interface_name}
     virtual_router_id 51
     priority 101
 

--- a/templates/keepalived_master.tpl
+++ b/templates/keepalived_master.tpl
@@ -10,7 +10,7 @@ vrrp_script check_haproxy {
 
 vrrp_instance VI_01 {
     state MASTER
-    interface ens192
+    interface ens160
     virtual_router_id 51
     priority 101
 

--- a/templates/keepalived_slave.tpl
+++ b/templates/keepalived_slave.tpl
@@ -10,7 +10,7 @@ vrrp_script check_haproxy {
 
 vrrp_instance VI_01 {
     state SLAVE
-    interface ens192
+    interface ens160
     virtual_router_id 51
     priority 100
 

--- a/templates/keepalived_slave.tpl
+++ b/templates/keepalived_slave.tpl
@@ -10,7 +10,7 @@ vrrp_script check_haproxy {
 
 vrrp_instance VI_01 {
     state SLAVE
-    interface ens160
+    interface ${interface_name}
     virtual_router_id 51
     priority 100
 

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -116,6 +116,9 @@ vm_haproxy_ram = "1024"
 # The IP address of the load balancer floating VIP #
 vm_haproxy_vip = ""
 
+# The name of the network interface in the HAProxy template - i.e. ens160
+vm_haproxy_nic = ""
+
 # The IP address of the load balancer virtual machine #
 vm_haproxy_ips = {
   "0" = ""

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,10 @@ variable "vm_haproxy_vip" {
   description = "IP used for the HAProxy floating VIP"
 }
 
+variable "vm_haproxy_nic" {
+  description = "Interface name used in HAProxy VM"
+}
+
 variable "vm_haproxy_ips" {
   type        = "map"
   description = "IP used for two HAProxy virtual machine"

--- a/vsphere-kubespray.tf
+++ b/vsphere-kubespray.tf
@@ -160,7 +160,7 @@ data "template_file" "keepalived_master" {
 
   vars = {
     virtual_ip = "${var.vm_haproxy_vip}"
-    interface_name = ${var.vm_haproxy_nic}"
+    interface_name = "${var.vm_haproxy_nic}"
   }
 }
 

--- a/vsphere-kubespray.tf
+++ b/vsphere-kubespray.tf
@@ -160,6 +160,7 @@ data "template_file" "keepalived_master" {
 
   vars = {
     virtual_ip = "${var.vm_haproxy_vip}"
+    interface_name = ${var.vm_haproxy_nic}"
   }
 }
 
@@ -169,6 +170,7 @@ data "template_file" "keepalived_slave" {
 
   vars = {
     virtual_ip = "${var.vm_haproxy_vip}"
+    interface_name = ${var.vm_haproxy_nic}"
   }
 }
 


### PR DESCRIPTION
I had an issue deploying due to my ubuntu template having interfaces named ens160 instead of ens192.  Modified relevant files and tested.