### PR TITLE
Fix so that kubectl exec doesn't disconnect after 50 seconds

### DIFF
--- a/templates/haproxy.tpl
+++ b/templates/haproxy.tpl
@@ -22,8 +22,8 @@ defaults
 	option	httplog
 	option	dontlognull
         timeout connect 5000
-        timeout client  50000
-        timeout server  50000
+        timeout client  4h
+        timeout server  4h
 
 frontend kubernetes
 	bind ${bind_ip}:6443


### PR DESCRIPTION
The default setup of the haproxy causes kubectl exec to exit after 50 seconds, this fix will allow you do work in a container for 4h before connection is terminated.